### PR TITLE
Add dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ How? Just run the script! (as regular user)
 
 `./displaylink-debian.sh`
 
-but first make sure following dependencies are installed:
-
-`apt-get install unzip linux-headers-$(uname -r) dkms lsb-release`
-
 #### Technical
 
 ##### displaylink-debian.sh

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -8,8 +8,33 @@
 version=1.0.335
 driver_dir=$version
 
-# ToDo: add dependency check on:
-# unzip linux-headers-$(uname -r) dkms lsb-release
+# Dependencies
+deps=(unzip linux-headers-$(uname -r) dkms lsb-release)
+
+dep_check() {
+   echo "Checking dependencies..."
+   for dep in ${deps[@]}
+   do
+      if ! dpkg -s $dep > /dev/null 2>&1
+      then
+	 read -p "$dep not found! Install? [y/N] " response
+	 response=${response,,} # tolower
+	 if [[ $response =~ ^(yes|y)$ ]]
+	 then
+	    if ! sudo apt-get install $dep
+	    then
+	       echo "$dep installation failed.  Aborting."
+	       exit 1
+	    fi
+	 else
+	    echo "Cannot continue without $dep.  Aborting."
+	    exit 1
+	 fi
+      else
+	 echo "$dep is installed"
+      fi
+   done
+}
 
 distro_check(){
 
@@ -21,6 +46,9 @@ then
 	# Add platform type message for RedHat
 	exit 1
 else
+
+# Confirm dependencies are in place
+dep_check
 
 # Checker parameters 
 lsb="$(lsb_release -is)"


### PR DESCRIPTION
Added dependency checks and some hand-holding to install missing 
dependencies after confirming we're not on RedHat (because we don't 
need tools to confirm that and wouldn't have dpkg/apt if we were) and 
before we figure out if we're on Debian or Ubuntu (because we need
lsb-release for that).