### PR TITLE
Upstream service name change

### DIFF
--- a/post-install-guide.md
+++ b/post-install-guide.md
@@ -7,15 +7,15 @@
 
 * After reboot, make sure dispaylink is running, i.e:
 
-  ```systemctl status displaylink.service```
+  ```systemctl status dlm.service```
   
   If it's not running, start it by running:
   
-  ```systemctl start displaylink.service```
+  ```systemctl start dlm.service```
   
   To start automatically at boot run:
   
-  ```systemctl enable displaylink.service```
+  ```systemctl enable dlm.service```
 
 ### Setting provider sources
 


### PR DESCRIPTION
Upstream has changed the name of the systemd service from `displaylink` to `dlm`.  The tests explained here work fine if you substitute `dlm.service` for `displaylink.service`.  You can see the new file name in the `add_systemd_service()` function in `1.2.58/displaylink-driver-1.2.58/displaylink-installer.sh` starting on line 112.

rcw@antec:~/Projects/displaylink-debian/1.2.58/displaylink-driver-1.2.58$ systemctl status displaylink.service
Unit displaylink.service could not be found.
rcw@antec:~/Projects/displaylink-debian/1.2.58/displaylink-driver-1.2.58$ systemctl status dlm.service
● dlm.service - DisplayLink Manager Service
   Loaded: loaded (/lib/systemd/system/dlm.service; static; vendor preset: enabled)
   Active: active (running) since Sat 2016-10-15 06:33:22 PDT; 12min ago
  Process: 3461 ExecStartPre=/sbin/modprobe evdi (code=exited, status=0/SUCCESS)
 Main PID: 3479 (DisplayLinkMana)
    Tasks: 24 (limit: 4915)
   CGroup: /system.slice/dlm.service
           └─3479 /opt/displaylink/DisplayLinkManager
rcw@antec:~/Projects/displaylink-debian/1.2.58/displaylink-driver-1.2.58$

Fixes #23