### PR TITLE
Added Linux Mint Tara to supported platforms.

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -130,7 +130,7 @@ then
 # Mint
 elif [ "$lsb" == "LinuxMint" ];
 then
-	if [ $codename == "sarah" ] || [ $codename == "rosa" ] || [ $codename == "petra" ] || [ $codename == "olivia" ] || [ $codename == "serena" ] || [ $codename == "sonya" ] || [ $codename == "sylvia" ];
+	if [ $codename == "sarah" ] || [ $codename == "rosa" ] || [ $codename == "petra" ] || [ $codename == "olivia" ] || [ $codename == "serena" ] || [ $codename == "sonya" ] || [ $codename == "sylvia" ] || [ $codename == "tara" ];
 	then
 		echo -e "\nPlatform requirements satisfied, proceeding ..."
 	else


### PR DESCRIPTION
Tested on UEFI platform.

The downloaded installer got caught on whiptail console windows asking for approval/password for UEFI signage of docking station hardware.
(Which then of course were unavailable to me when running the installer-script contained in this repo, maybe that could be a future improvement)?

However, my workstation (Dell Latitude 5590) was already UEFI configured, so after completing the 4.2 installer by manual execution (without using the script in this repo), I was able to use my UEFI password to sign the hardware at next boot (with the hardware connected through boot).

I therefore submit/suggest Linux Mint 19 Tara be added to the list, seeing as I'm now connected to two screens through the docking station (Dell D6000). =) 