### PR TITLE
Fixed dlurl definition

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -14,7 +14,7 @@
 # define the version to get as the latest available version
 version=`wget -q -O - https://www.displaylink.com/downloads/ubuntu | grep "download-version" | head -n 1 | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/'`
 # define download url to be the correct version
-dlurl="https://www.displaylink.com/"`wget -q -O - https://www.displaylink.com/downloads/ubuntu | grep "download-link" | head -n 1 | perl -pe '($_)=/<a href="\/([^"]+)"[^>]+class="download-link"/'`
+dlurl="https://www.displaylink.com/"`wget -q -O - https://www.displaylink.com/downloads/ubuntu | grep 'class="download-link"' | head -n 1 | perl -pe '($_)=/<a href="\/([^"]+)"[^>]+class="download-link"/'`
 driver_dir=$version
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/" && pwd )"
 


### PR DESCRIPTION
The webpage https://www.displaylink.com/downloads/ubuntu has changed. The line with first occurrance of "download-link" doesn't contain the link anymore. This commit updates the grep to match the download link properly.