### PR TITLE
adds libelf-dev

### DIFF
--- a/evdi.sh
+++ b/evdi.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-apt-get install -y libdrm-dev
+apt-get install -y libdrm-dev libelf-dev
 git clone https://github.com/DisplayLink/evdi.git
 cd evdi
 wget https://crazy.dev.frugalware.org/evdi-all-in-one-fixes.patch


### PR DESCRIPTION
libelf-dev is required otherwise compilation fails on ubuntu 18.04 (and probably most debian based distros).

This gets hinted at in the official installer
error: Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y, please install libelf-dev, libelf-devel or elfutils-libelf-devel
This causes Make to fail on your build too.

Tried on a fresh install of 18.04 with a kernel 5.4.6 and it makes it work.