### PR TITLE
Bug fix: Installation fails if a prior $driver_dir folder exists (cannot mkdir)

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -365,6 +365,13 @@ separator
 download
 
 # prep
+# Check whether prior drivers have been downloaded
+if [ -d $driver_dir ]
+then
+	echo "Removing prior: \"$driver_dir\" directory"
+	rm -r $driver_dir
+fi
+
 mkdir $driver_dir
 
 separator


### PR DESCRIPTION
Bug fix:
Removing older instance of $driver_dir during prep, so we can download latest...
