### PR TITLE
Update README.md: Ubuntu 20.04 Focal Fossa tested OK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Before submitting a bug report in the [issue tracker](https://github.com/AdnanHo
 #### Supported platforms are:
 
   * Debian: Jessie 8.0/Stretch 9.0/Buster 10/Bullseye (testing)/Sid (unstable)
-  * Ubuntu: 14.04 Trusty/15.04 Vivid/15.10 Wily/16.04 Xenial/16.10 Yakkety/17.04 Zesty/17.10 Artful/18.04 Bionic/19.04 Disco/Ubuntu 19.10 Eoan
+  * Ubuntu: 14.04 Trusty/15.04 Vivid/15.10 Wily/16.04 Xenial/16.10 Yakkety/17.04 Zesty/17.10 Artful/18.04 Bionic/19.04 Disco/19.10 Eoan/20.04 Focal
   * elementary OS: O.3 Freya/0.4 Loki/5.0 Juno
   * Mint: 15 Olivia/16 Petra/17.3 Rosa/18 Sarah/18.3 Sylvia/19.1 Tessa
   * Kali: kali-rolling/2016.2/2017.3/2018.3/2018.4


### PR DESCRIPTION
--------------- Linux system info ----------------

Distro: Ubuntu
Release: focal
Kernel: 5.4.0-28-generic

---------------- DisplayLink info ----------------

Driver version: 1.6.0+dfsg
5.2.14
DisplayLink service status: up and running
EVDI service version: 1.6.4

------------------ Graphics card -----------------

Vendor: i915
intel_ish_ipc
Subsystem: 615
Integrated
VGA: Intel Corporation UHD Graphics 615 (rev 02)
VGA (3D): 
X11 version: 1.20.8-2ubuntu2
X11 configs: /etc/X11/xorg.conf.d/20-displaylink.conf

-------------- DisplayLink xorg.conf -------------

File: /etc/X11/xorg.conf.d/20-displaylink.conf
Contents:
 Section "OutputClass"
    Identifier  "DisplayLink"
    MatchDriver "evdi"
    Driver      "modesetting"
    Option      "AccelMethod" "none"
EndSection

-------------------- Monitors --------------------

Providers: number : 3
Provider 0: id: 0x47 cap: 0x9, Source Output, Sink Offload crtcs: 3 outputs: 5 associated providers: 2 name:modesetting
Provider 1: id: 0x10d cap: 0x2, Sink Output crtcs: 1 outputs: 1 associated providers: 1 name:modesetting
Provider 2: id: 0xe6 cap: 0x2, Sink Output crtcs: 1 outputs: 1 associated providers: 1 name:modesetting

-------------------------------------------------------------------