### PR TITLE
Fix syntax error near in displaylink-debian.sh

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -95,6 +95,7 @@ if [ "$lsb" == "Deepin" ];
 then
 	deps=(unzip linux-headers-$(uname -r) dkms lsb-release linux-source-deepin x11-xserver-utils wget)
 elif [ "$lsb" == "PureOS" ];
+then
 	deps=(unzip linux-headers-$(uname -r) dkms lsb-release linux-source x11-xserver-utils wget libdrm-dev)
 else
 	deps=(unzip linux-headers-$(uname -r) dkms lsb-release linux-source x11-xserver-utils wget)
@@ -242,7 +243,7 @@ then
 		message
 		exit 1
 	fi
-# Parrot 
+# Parrot
 elif [ "$lsb" == "Parrot" ];
 then
 	if [ $codename == "n/a" ];


### PR DESCRIPTION
When running the displaylink-debian.sh bash script, the following error is displayed:

/displaylink-debian.sh: line 99: syntax error near unexpected token `else'

Added `then` to elif to resolve error.