### PR TITLE
fix for issue #413 'Invalid number of arguments passed.'

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -443,11 +443,11 @@ separator
 tgzName=`ls $driver_dir/displaylink-driver-${version}/*.gz | cut -d'/' -f3`
 cd ./evdi/module/
 tar -czf $tgzName *
-cp -f $tgzName ../../$driver_dir/displaylink-driver-${version}/$tgzName
+cp -f $tgzName ../$driver_dir/displaylink-driver-${version}/$tgzName
 #Replace Broken libs with new compiled ones
-cp -f ../library/libevdi.so.1.* ../../$driver_dir/displaylink-driver-${version}/x64-ubuntu-1604/libevdi.so
-cp -f ../library/libevdi.so.1.* ../../$driver_dir/displaylink-driver-${version}/x86-ubuntu-1604/libevdi.so
-cd ../../
+cp -f library/libevdi.so.1.* ../$driver_dir/displaylink-driver-${version}/x64-ubuntu-1604/libevdi.so
+cp -f library/libevdi.so.1.* ../$driver_dir/displaylink-driver-${version}/x86-ubuntu-1604/libevdi.so
+cd ../
 rm -rf evdi/
 ############################################################
 ####END of Modifications for EVDI Kernel 5.4 issues     ####

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -441,7 +441,7 @@ separator
 ./evdi.sh
 #Replace Broken tgz with new
 tgzName=`ls $driver_dir/displaylink-driver-${version}/*.gz | cut -d'/' -f3`
-cd ./evdi/module/
+cd ./evdi
 tar -czf $tgzName *
 cp -f $tgzName ../$driver_dir/displaylink-driver-${version}/$tgzName
 #Replace Broken libs with new compiled ones


### PR DESCRIPTION
Corrected paths so the error message "Invalid number of arguments passed." won't pop up on "Linux Mint 19.3 Cinnamon".
Can't estimate if that might break on other distributions.