### PR TITLE
Overwrite existing destination file when creating build/Kconfig link.

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -428,7 +428,7 @@ sed -i "s/SYSTEMINITDAEMON=unknown/SYSTEMINITDAEMON=$sysinitdaemon/g" $driver_di
 if [ "$lsb" == "Debian" ] || [ "$lsb" == "Devuan" ] || [ "$lsb" == "Kali" ] || [ "$lsb" == "Deepin" ] || [ "$lsb" == "BunsenLabs" ] || [ "$lsb" == "MX" ];
 then
 	sed -i 's#/lib/modules/$KVER/build/Kconfig#/lib/modules/$KVER/build/scripts/kconfig/conf#g' $driver_dir/displaylink-driver-${version}/displaylink-installer.sh
-	ln -s /lib/modules/$(uname -r)/build/Makefile /lib/modules/$(uname -r)/build/Kconfig
+	ln -sf /lib/modules/$(uname -r)/build/Makefile /lib/modules/$(uname -r)/build/Kconfig
 fi
 
 


### PR DESCRIPTION
This is to fix the following error message as outlined in https://github.com/AdnanHodzic/displaylink-debian/issues/431,
ln: failed to create symbolic link '/lib/modules/4.19.0-8-amd64/build/Kconfig': File exists

Note, this only fixes the issue if the file aleady exists, it will not fix a missing parent directory.