### PR TITLE
Fix for wrong evdi version & conf creation bug

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -453,6 +453,13 @@ rm -rf evdi/
 ####END of Modifications for EVDI Kernel 5.4 issues     ####
 ############################################################
 
+# Patch displaylink-installer.sh to prevent reboot before our script is done.
+resourcesDir="$(pwd)/resources/"
+patchName="displaylink-installer.patch"
+finalPatchPath="$resourcesDir$patchName"
+patch -Np0 $driver_dir/displaylink-driver-${version}/displaylink-installer.sh <$finalPatchPath
+
+
 # run displaylink install
 echo -e "\nInstalling driver version: $version\n"
 cd $driver_dir/displaylink-driver-${version}

--- a/evdi.sh
+++ b/evdi.sh
@@ -10,6 +10,8 @@ externalPatchDomain="https://crazy.dev.frugalware.org/"
 currentEvdiPatch="eaiof.patch"
 patchFileName="evdi-all-in-one-fixes.patch"
 
+# displaylink-installer patch local resources
+displayLinkInstallerPatch="displaylink-installer.patch"
 
 #EVDI Web resources
 externalPatchURL=$externalPatchDomain$patchFileName
@@ -36,8 +38,8 @@ fi
 
 
 cd "$resourcesDir"
-#remove all files except current local patch - if it's present
-find . ! -name $currentEvdiPatch -delete
+#remove all files except current local patch and display-link-installer.patch - if it's present
+find . ! -name $currentEvdiPatch $displayLinkInstallerPatch  -delete
 
 #download any new patch
 echo "$externalPatchURL"

--- a/evdi.sh
+++ b/evdi.sh
@@ -68,7 +68,7 @@ if [ -d $evdiDir ] ; then
 	rm -rf $evdiDir
 fi
 
-git clone $evdiURL
+git clone --depth=1 --branch v1.7.0 $evdiURL
 cd "$evdiDir"
 if [ "$commitPatch" = "true" ] ; then
 	cp $commitPatchPath $evdiDir

--- a/resources/displaylink-installer.patch
+++ b/resources/displaylink-installer.patch
@@ -1,0 +1,19 @@
+--- /opt/displaylink/displaylink-installer.sh
++++ /opt/displaylink/displaylink-installer.sh
+@@ -457,11 +457,11 @@
+   echo "http://support.displaylink.com/knowledgebase/topics/103927-troubleshooting-ubuntu"
+ 
+   echo -e "\nInstallation complete!"
+-  echo -e "\nPlease reboot your computer if intending to use Xorg."
+-  $XORG_RUNNING || exit 0
+-  read -p 'Xorg is running. Do you want to reboot now? (Y/n)' CHOICE
+-  [[ ${CHOICE:-Y} =~ ^[Nn]$ ]] && exit 0
+-  reboot
++  #echo -e "\nPlease reboot your computer if intending to use Xorg."
++  #$XORG_RUNNING || exit 0
++  #read -p 'Xorg is running. Do you want to reboot now? (Y/n)' CHOICE
++  #[[ ${CHOICE:-Y} =~ ^[Nn]$ ]] && exit 0
++  #reboot
+ }
+ 
+ uninstall()


### PR DESCRIPTION
This PR introduces fixes for these issues:

- Apparently displaylink-manager is expecting v1.7.0 instead of the latest v1.8.0.
Thanks to  AlainKnaff for finding the issue: https://github.com/AdnanHodzic/displaylink-debian/issues/451#issuecomment-670852323
- A proposed reboot from displaylink-installer.sh prevents displaylink-debian.sh to finish the install procedure and no conf file is generated. 
Thanks to rdmtinez for mentioning this https://github.com/AdnanHodzic/displaylink-debian/issues/430#issuecomment-671061085