### PR TITLE
Perform case insensitive comparison of lsb_release for LinuxMint

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -193,7 +193,8 @@ then
         exit 1
     fi
 # Mint
-elif [ "$lsb" == "Linuxmint" ];
+# Issue 464	
+elif echo $lsb | grep -qi "Linuxmint" ;
 then
 	if [ $codename == "sarah" ] || [ $codename == "rosa" ] || [ $codename == "petra" ] || [ $codename == "olivia" ] || [ $codename == "serena" ] || [ $codename == "sonya" ] || [ $codename == "sylvia" ] || [ $codename == "tara" ] || [ $codename == "tessa" ] || [ $codename == "betsy" ] || [ $codename == "cindy" ] || [ $codename == "tina" ] || [ $codename == "tricia" ] || [ $codename == "debbie" ] || [ $codename == "ulyana" ];
 	then


### PR DESCRIPTION
Some users have reported that the output of  `lsb_release -is` was "Linuxmint" and others had "LinuxMint".


Closes #464