### PR TITLE
make script work, if no VGA compatible controller is installed

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -32,7 +32,7 @@ kernel="$(uname -r)"
 xorg_config_displaylink="/etc/X11/xorg.conf.d/20-displaylink.conf"
 blacklist="/etc/modprobe.d/blacklist.conf"
 sys_driver_version="$(ls /usr/src/ | grep "evdi" | cut -d "-" -f2)"
-vga_info="$(lspci | grep -oP '(?<=VGA compatible controller: ).*')"
+vga_info="$(lspci | grep -oP '(?<=VGA compatible controller: ).*')" || :
 vga_info_3d="$(lspci | grep -i '3d controller' | sed 's/^.*: //')"
 graphics_vendor="$(lspci -nnk | grep -i vga -A3 | grep 'in use' | cut -d ':' -f2 | sed 's/ //g')"
 graphics_subcard="$(lspci -nnk | grep -i vga -A3 | grep Subsystem | cut -d ' ' -f5)"


### PR DESCRIPTION
Because "set -e" in displaylink-debian.sh is set, also a grep with no output will stop the script.
I have a kvm without a VGA Card that has a usb3-PCIe card from the host system with a displaylink connected.
After the very small fix the displaylink-sdebian.sh script it worked.
Thank You for the good work.