### PR TITLE
improve nvidia detection for dual-card systems

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -693,8 +693,8 @@ EndSection
 EOL
 }
 
-# set xorg for Nvidia cards (issue: 176, 179, 211, 217)
-if [ "$drv_nvidia" == "NVIDIA" ] || [ "$drv" == "nvidia" ];
+# set xorg for Nvidia cards (issue: 176, 179, 211, 217, 596)
+if [ "$drv_nvidia" == "NVIDIA" ] || [[ $drv == *"nvidia"* ]];
 then
 		nvidia_pregame
 		xorg_nvidia


### PR DESCRIPTION
Some dual-card systems end up with `$drv` having values like
`"i915\nnvidia"`, and string equality fails for those cases. Use
bash wildcards instead to see if `$drv` contains `"nvidia"`.

fixes #596