### PR TITLE
Debian Bookworm (testing) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Before submitting a bug report in the [issue tracker](https://github.com/AdnanHo
 
 #### Supported platforms are:
 
-  * Debian: Jessie 8.0/Stretch 9.0/Buster 10/Bullseye (testing)/Sid (unstable)
+  * Debian: Jessie 8.0/Stretch 9.0/Buster 10/Bullseye 11/Bookworm (testing)/Sid (unstable)
   * Ubuntu: 14.04 Trusty - 21.04 Hirsute
   * elementary OS: 0.3 Freya- 5.1 Hera
   * Mint: 15 Olivia / 20.2 Uma

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -173,7 +173,7 @@ then
 # Debian
 elif [ "$lsb" == "Debian" ];
 then
-	if [ $codename == "jessie" ] || [ $codename == "stretch" ] || [ $codename == "buster" ] || [ $codename == "bullseye" ] || [ $codename == "sid" ] || [ $codename == "n/a" ];
+	if [ $codename == "jessie" ] || [ $codename == "stretch" ] || [ $codename == "buster" ] || [ $codename == "bullseye" ] || [ $codename == "bookworm" ] || [ $codename == "sid" ] || [ $codename == "n/a" ];
 	then
 		echo -e "\nPlatform requirements satisfied, proceeding ..."
 	else


### PR DESCRIPTION
Debian Bullseye is now stable. Fixes script and readme accordingly.

Fixes #611