### PR TITLE
Prevents system freeze in post-install

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -510,9 +510,8 @@ then
     # Fix inability to enable displaylink-driver.service
     sed -i "/RestartSec=5/a[Install]\nWantedBy=multi-user.target" /lib/systemd/system/displaylink-driver.service
 
-    echo "Enable and start displaylink-driver service"
+    echo "Enable displaylink-driver service"
     systemctl enable displaylink-driver.service
-    systemctl start displaylink-driver.service
 elif [ "$sysinitdaemon" == "sysvinit" ]
 then
     echo "Copying init script to /etc/init.d\n"


### PR DESCRIPTION
Starting `displaylink-driver.service` right after the installation leads to graphical system freeze on `Ubuntu 18.04` + `xserver-xorg-core` + `4.15.0-122-generic`
No need to start the service since `enable` has been been executed already and a system restart is required right after.
`enable` will take care of starting the service on the next boot.