### PR TITLE
added Ubuntu 21.10 codename impish to the ubuntu checks

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -153,7 +153,7 @@ echo -e "\n---------------------------------------------------------------\n"
 # Ubuntu
 if [ "$lsb" == "Ubuntu" ] || [ "$lsb" == "Neon" ];
 then
-	if [ $codename == "trusty" ] || [ $codename == "vivid" ] || [ $codename == "wily" ] || [ $codename == "xenial" ] || [ $codename == "yakkety" ] || [ $codename == "zesty" ] || [ $codename == "artful" ] || [ $codename == "bionic" ] || [ $codename == "cosmic" ] || [ $codename == "disco" ] || [ $codename == "eoan" ] || [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ];
+	if [ $codename == "trusty" ] || [ $codename == "vivid" ] || [ $codename == "wily" ] || [ $codename == "xenial" ] || [ $codename == "yakkety" ] || [ $codename == "zesty" ] || [ $codename == "artful" ] || [ $codename == "bionic" ] || [ $codename == "cosmic" ] || [ $codename == "disco" ] || [ $codename == "eoan" ] || [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ] || [ $codename == "impish" ];
 	then
 		echo -e "\nPlatform requirements satisfied, proceeding ..."
 	else
@@ -255,7 +255,7 @@ then
 # PopOS
 elif [ "$lsb" == "Pop" ];
 then
-	if [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ] || [ $codename == "n/a" ];
+	if [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ]|| [ $codename == "impish" ] || [ $codename == "n/a" ];·
 	then
 		echo -e "\nPlatform requirements satisfied, proceeding ..."
 	else


### PR DESCRIPTION
I tested this on my laptop running Xubuntu and it seems to
work with no further modification, though I did need to
delete my displaylink X11 config for it to work, but after
that nothing else was required

closes #630 