### PR TITLE
Added link to "Can't open display" error issue in the troubleshooting section

### DIFF
--- a/post-install-guide.md
+++ b/post-install-guide.md
@@ -152,6 +152,8 @@ Note, in case you're editting ```~/.bashrc```, make sure you run ```source ~/.ba
 
 * [mouse/cursor flicker issue](https://github.com/AdnanHodzic/displaylink-debian/issues/192)
 
+* [`Can't open display :0` error](https://github.com/AdnanHodzic/displaylink-debian/issues/639)
+
 ##### Monitoring for errors
 
 * Monitor ```dmesg | grep Display``` output while plugging in Displaylink


### PR DESCRIPTION
On some distributions (at least Debian Bookworm/Sid) the sudo command does not preserve the user's environment, and thus the `-E` flag must be supplied to the sudo command. I created issue  #639 for this, where this solution can be found.