### PR TITLE
Xrandr independant

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -66,7 +66,7 @@ vga_info="$(lspci | grep -oP '(?<=VGA compatible controller: ).*')" || :
 vga_info_3d="$(lspci | grep -i '3d controller' | sed 's/^.*: //')"
 graphics_vendor="$(lspci -nnk | grep -i vga -A3 | grep 'in use' | cut -d ':' -f2 | sed 's/ //g')"
 graphics_subcard="$(lspci -nnk | grep -i vga -A3 | grep Subsystem | cut -d ' ' -f5)"
-providers="$(xrandr --listproviders 2>/dev/null || echo "*")"
+providers="$(xrandr --listproviders 2>/dev/null || echo '*')"
 xorg_vcheck="$(dpkg -l | grep "ii  xserver-xorg-core" | awk '{print $3}' | sed 's/[^,:]*://g')"
 min_xorg=1.18.3
 newgen_xorg=1.19.6

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -66,7 +66,7 @@ vga_info="$(lspci | grep -oP '(?<=VGA compatible controller: ).*')" || :
 vga_info_3d="$(lspci | grep -i '3d controller' | sed 's/^.*: //')"
 graphics_vendor="$(lspci -nnk | grep -i vga -A3 | grep 'in use' | cut -d ':' -f2 | sed 's/ //g')"
 graphics_subcard="$(lspci -nnk | grep -i vga -A3 | grep Subsystem | cut -d ' ' -f5)"
-providers="$(xrandr --listproviders)"
+providers="$(xrandr --listproviders 2>/dev/null || echo "*")"
 xorg_vcheck="$(dpkg -l | grep "ii  xserver-xorg-core" | awk '{print $3}' | sed 's/[^,:]*://g')"
 min_xorg=1.18.3
 newgen_xorg=1.19.6


### PR DESCRIPTION
Hi, 

I updated (uninstalled & re-installed) displaylink driver using displaylink-debian today, but at the reboot I got a black screen after lightdm started - no login possible. This is reproducible.
As I was able to work normally from console, though, I wanted to uninstall displaylink. But the script doesn't work from console, giving the error : "Can't open display".  

It's due to the line 69 : 
`providers="$(xrandr --listproviders)"`
that is only used for debug purpose at line 892
`echo -e "$providers"`

This pull request simply updates line 892 to :
`providers="$(xrandr --listproviders 2>/dev/null || echo '*')"`

Making the uninstall working from console and my laptop usable again. 

(No investigation on the root cause yet...)
