### PR TITLE
Support kernel 5.18

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -17,7 +17,7 @@ set -eu
 IFS=$'\n\t'
 
 kernel_check="$(uname -r | egrep -o '[0-9]+\.[0-9]+')"
-max_kernel_version_supported="5.17"
+max_kernel_version_supported="5.18"
 
 function ver2int {
 echo "$@" | awk -F "." '{ printf("%03d%03d%03d\n", $1,$2,$3); }';


### PR DESCRIPTION
Confirmed functional on `Linux version 5.18.0-2-amd64 (debian-kernel@lists.debian.org) (gcc-11 (Debian 11.3.0-3) 11.3.0, GNU ld (GNU Binutils for Debian) 2.38.50.20220615) #1 SMP PREEMPT_DYNAMIC Debian 5.18.5-1 (2022-06-16)`