### PR TITLE
kernel_check now handles correctly kernel version 5.19.0-0.deb11.2-amd64

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -16,7 +16,7 @@ set -eu
 # set -o pipefail # TODO: Some code still fails this check, fix before enabling.
 IFS=$'\n\t'
 
-kernel_check="$(uname -r | egrep -o '[0-9]+\.[0-9]+')"
+kernel_check="$(uname -r | egrep -o '[0-9]+\.[0-9]+' | head -1)"
 max_kernel_version_supported="5.19"
 
 function ver2int {


### PR DESCRIPTION
displaylink-debian is supposed to support kernel versions up to 5.19 inclusive.
However, in my Debian Bullseye, I use kernel version 5.19.0-0.deb11.2-amd64 from bullseye-backports.
This version string causes kernel check to fail because the `kernel_check` code outputs two lines:
```
5.19
11.2
```
So `ver2int` interprets it as `005019002` which is greater than the output of
```ver2int $max_kernel_version_supported```
which is `005019000`.
causing a false failure of the version check.

This pull request fixes the problem by limiting `kernel_check` to the first line.

Alternatively, the bug can be fixed by changing `max_kernel_version_supported` to `5.19.999` (DISCLAIMER: I did not verify this alternative).