### PR TITLE
Added support for Parrot OS 5.1 (Electro Ara); Codename 'ara'

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -253,7 +253,7 @@ then
 # Parrot
 elif [ "$lsb" == "Parrot" ];
 then
-	if [ $codename == "n/a" ] || [ $codename == "lts" ];
+	if [ $codename == "n/a" ] || [ $codename == "lts" ] || [ $codename == "ara" ];
 	then
 		echo -e "\nPlatform requirements satisfied, proceeding ..."
 	else


### PR DESCRIPTION
I made a small modification to add support for Parrot OS codename 'ara'. I was able to successfully get my DisplayLink monitor working. Please let me know if anything else is needed before these changes can be merged.

Here are my debug results:

```
--------------- Linux system info ----------------

Distro: Parrot
Release: ara
Kernel: 6.0.0-12parrot1-amd64

---------------- DisplayLink info ----------------

Driver version: 1.12.0
DisplayLink service status: up and running
EVDI service version: 1.12.0

------------------ Graphics card -----------------

Vendor: i915
Subsystem: [17aa:5078]
VGA: Intel Corporation CometLake-U GT2 [UHD Graphics] (rev 02)
VGA (3D): 
X11 version: 1.20.11-1+deb11u4
X11 configs: /etc/X11/xorg.conf.d/00-keyboard.conf /etc/X11/xorg.conf.d/20-displaylink.conf

-------------- DisplayLink xorg.conf -------------

File: /etc/X11/xorg.conf.d/20-displaylink.conf
Contents:
 Section "OutputClass"
    Identifier  "DisplayLink"
    MatchDriver "evdi"
    Driver      "modesetting"
    Option      "AccelMethod" "none"
EndSection

-------------------- Monitors --------------------

Providers: number : 5
Provider 0: id: 0x47 cap: 0xf, Source Output, Sink Output, Source Offload, Sink Offload crtcs: 3 outputs: 5 associated providers: 4 name:modesetting
Provider 1: id: 0x13b cap: 0x2, Sink Output crtcs: 1 outputs: 1 associated providers: 1 name:modesetting
Provider 2: id: 0x119 cap: 0x2, Sink Output crtcs: 1 outputs: 1 associated providers: 1 name:modesetting
Provider 3: id: 0xf7 cap: 0x2, Sink Output crtcs: 1 outputs: 1 associated providers: 1 name:modesetting
Provider 4: id: 0xd5 cap: 0x2, Sink Output crtcs: 1 outputs: 1 associated providers: 1 name:modesetting
```