### PR TITLE
Fix evdi module patch (#811)

### DIFF
--- a/resources/evdi.patch
+++ b/resources/evdi.patch
@@ -3,7 +3,7 @@
 @@ -26,7 +26,7 @@
  #include <drm/drmP.h>
  #endif
- #if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE || defined(EL9)
+ #if KERNEL_VERSION(5, 15, 0) <= LINUX_VERSION_CODE
 -#include <drm/drm_legacy.h>
 +#include <drm/drm_framebuffer.h>
  #else


### PR DESCRIPTION
The `evdi.patch` is reject, breaking kernel 6+ compatibility. This PR fix it.