### PR TITLE
Debian Trixie (testing) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before submitting a bug report in the [issue tracker](https://github.com/AdnanHo
 
 ## Supported platforms are:
 
-  * Debian: Jessie 8.0/Stretch 9.0/Buster 10/Bullseye 11/Bookworm (testing)/Sid (unstable)
+  * Debian: Jessie 8.0/Stretch 9.0/Buster 10/Bullseye 11/Bookworm 12/Trixie(testing)/Sid (unstable)
   * Ubuntu: 14.04 Trusty - 23.04 Lunar
   * elementary OS: 0.3 Freya- 7.0 Horus
   * Mint: 15 Olivia / 21.1 Vera

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -181,7 +181,7 @@ then
 # Debian
 elif [ "$lsb" == "Debian" ];
 then
-	if [ $codename == "jessie" ] || [ $codename == "stretch" ] || [ $codename == "buster" ] || [ $codename == "bullseye" ] || [ $codename == "bookworm" ] || [ $codename == "sid" ] || [ $codename == "n/a" ];
+	if [ $codename == "jessie" ] || [ $codename == "stretch" ] || [ $codename == "buster" ] || [ $codename == "bullseye" ] || [ $codename == "bookworm" ] || [ $codename == "trixie" ] || [ $codename == "sid" ] || [ $codename == "n/a" ];
 	then
 		echo -e "\nPlatform requirements satisfied, proceeding ..."
 	else


### PR DESCRIPTION
Debian Bookworm is now stable. Fixes script and readme accordingly.
Fixes https://github.com/AdnanHodzic/displaylink-debian/issues/840