### PR TITLE
Add shebang

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 #
 # displaylink-debian:
 # DisplayLink driver installer for Debian and Ubuntu based Linux distributions: Debian, Ubuntu, Elementary OS,


### PR DESCRIPTION
Otherwise, script may be started with other interpreters.

For example, on Debian testing `dash` was used for me, and I've got `./displaylink-debian.sh: 20: function: not found` error.