### PR TITLE
Support Ubuntu mantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Before submitting a bug report in the [issue tracker](https://github.com/AdnanHo
 ## Supported platforms are:
 
   * Debian: Jessie 8.0/Stretch 9.0/Buster 10/Bullseye 11/Bookworm 12/Trixie(testing)/Sid (unstable)
-  * Ubuntu: 14.04 Trusty - 23.04 Lunar
+  * Ubuntu: 14.04 Trusty - 23.10 Mantic
   * elementary OS: 0.3 Freya- 7.0 Horus
   * Mint: 15 Olivia - 21.2 Victoria
   * LMDE: 2 Betsy - 6 Faye

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -161,7 +161,7 @@ echo -e "\n---------------------------------------------------------------\n"
 # Ubuntu
 if [ "$lsb" == "Ubuntu" ] || [ "$lsb" == "Neon" ];
 then
-	if [ $codename == "trusty" ] || [ $codename == "vivid" ] || [ $codename == "wily" ] || [ $codename == "xenial" ] || [ $codename == "yakkety" ] || [ $codename == "zesty" ] || [ $codename == "artful" ] || [ $codename == "bionic" ] || [ $codename == "cosmic" ] || [ $codename == "disco" ] || [ $codename == "eoan" ] || [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ] || [ $codename == "impish" ] || [ $codename == "jammy" ] || [ $codename == "kinetic" ] || [ $codename == "lunar" ];
+	if [ $codename == "trusty" ] || [ $codename == "vivid" ] || [ $codename == "wily" ] || [ $codename == "xenial" ] || [ $codename == "yakkety" ] || [ $codename == "zesty" ] || [ $codename == "artful" ] || [ $codename == "bionic" ] || [ $codename == "cosmic" ] || [ $codename == "disco" ] || [ $codename == "eoan" ] || [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ] || [ $codename == "impish" ] || [ $codename == "jammy" ] || [ $codename == "kinetic" ] || [ $codename == "lunar" ] || [ $codename == "mantic" ];
 	then
 		echo -e "\nPlatform requirements satisfied, proceeding ..."
 	else


### PR DESCRIPTION
On my machine, running Ubuntu 23.10 Mantic, the script works as-is and I can use my dock. Hence, I’d suggest adding mantic to the list of supported codenames, and addressing bugs as they are found.