### PR TITLE
Add build-essential as dependancy

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -105,7 +105,7 @@ fi
 dep_check() {
 echo -e "\nChecking dependencies\n"
 
-deps=(unzip linux-headers-$(uname -r) dkms lsb-release linux-source x11-xserver-utils wget libdrm-dev libelf-dev git pciutils)
+deps=(unzip linux-headers-$(uname -r) dkms lsb-release linux-source x11-xserver-utils wget libdrm-dev libelf-dev git pciutils build-essential)
 
 for dep in ${deps[@]}
 do


### PR DESCRIPTION
We need dependency to build-essential to avoid the following error in the building step:
```
cc -I../module -std=gnu99 -fPIC -D_FILE_OFFSET_BITS=64  $(pkg-config --cflags-only-I libdrm)   -c -o evdi_lib.o evdi_lib.c
/bin/sh: 1: cc: not found
```