### PR TITLE
displaylink-debiah.sh: for -dev dependencies, explicitly specify the architecture

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -105,7 +105,9 @@ fi
 dep_check() {
 echo -e "\nChecking dependencies\n"
 
-deps=(unzip linux-headers-$(uname -r) dkms lsb-release linux-source x11-xserver-utils wget libdrm-dev libelf-dev git pciutils)
+dpkg_arch="$(dpkg --print-architecture)"
+
+deps=(unzip linux-headers-$(uname -r) dkms lsb-release linux-source x11-xserver-utils wget libdrm-dev:$dpkg_arch libelf-dev:$dpkg_arch git pciutils)
 
 for dep in ${deps[@]}
 do


### PR DESCRIPTION
Otherwise dpkg -s foo will complain if there are multiple architectures of the library installed.