### PR TITLE
Patch EVDI version for kernel > 6.1

### DIFF
--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -447,7 +447,16 @@ mv displaylink-driver-${version}[.\d]*-*[0-9]*.[0-9]*/ $driver_dir/displaylink-d
 # get sysinitdaemon
 sysinitdaemon=$(sysinitdaemon_get)
 
+if [ 1 -eq "$(echo "$kernel_check > 6.1" | bc)" ]
+then
+    echo "deleting old evdi archive"
+    rm $driver_dir/displaylink-driver-${version}/evdi.tar.gz
+    echo "downloading evdi compatible with kernel > 6.1"
+    curl -L https://github.com/DisplayLink/evdi/archive/refs/tags/v1.14.2.tar.gz -o $driver_dir/displaylink-driver-${version}/evdi.tar.gz
+fi
+
 # modify displaylink-installer.sh
+sed -i 's/  if ! tar xf "$TARGZ" -C "$EVDI"; then/  if ! tar xf "$TARGZ" -C "$EVDI" --strip-components=1; then/g' $driver_dir/displaylink-driver-${version}/displaylink-installer.sh
 sed -i "s/SYSTEMINITDAEMON=unknown/SYSTEMINITDAEMON=$sysinitdaemon/g" $driver_dir/displaylink-driver-${version}/displaylink-installer.sh
 
 # issue: 227

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -453,10 +453,10 @@ then
     rm $driver_dir/displaylink-driver-${version}/evdi.tar.gz
     echo "downloading evdi compatible with kernel > 6.1"
     curl -L https://github.com/DisplayLink/evdi/archive/refs/tags/v1.14.2.tar.gz -o $driver_dir/displaylink-driver-${version}/evdi.tar.gz
+    sed -i 's#if ! tar xf "$TARGZ" -C "$EVDI"; then#if ! tar xf "$TARGZ" -C "$EVDI" --strip-components=1; then#g' $driver_dir/displaylink-driver-${version}/displaylink-installer.sh
 fi
 
 # modify displaylink-installer.sh
-sed -i 's/  if ! tar xf "$TARGZ" -C "$EVDI"; then/  if ! tar xf "$TARGZ" -C "$EVDI" --strip-components=1; then/g' $driver_dir/displaylink-driver-${version}/displaylink-installer.sh
 sed -i "s/SYSTEMINITDAEMON=unknown/SYSTEMINITDAEMON=$sysinitdaemon/g" $driver_dir/displaylink-driver-${version}/displaylink-installer.sh
 
 # issue: 227


### PR DESCRIPTION
This is a small patch to get an up-to-date evdi version during the install process, this allow kernel > 6.1 to work with displaylink.

Patch tried on Debian sid, kernel 6.6.

This should be removed once the kernel from synaptic got an up-to-date evdi version