### PR TITLE
refactor: remove guard for known distro releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,20 +39,20 @@ Before submitting a bug report in the [issue tracker](https://github.com/AdnanHo
 
 ## Supported platforms are:
 
-* BunsenLabs: Helium - Boron
-  * Debian: Jessie 8.0/Stretch 9.0/Buster 10/Bullseye 11/Bookworm 12/Trixie(testing)/Sid (unstable)
-  * Deepin: stable - unstable
-  * Devuan: ASCII - Chimaera
-  * elementary OS: 0.3 Freya- 7.0 Horus
-  * Kali: kali-rolling/2016.2 - 2023.1
+  * BunsenLabs
+  * Debian
+  * Deepin
+  * Devuan
+  * elementary OS
+  * Kali
   * KDE neon
-  * LMDE: 2 Betsy - 6 Faye
-  * Mint: 15 Olivia - 21.3 Virginia
-  * MX Linux: 17.1/18
-  * Nitrux: nitrux
-  * Parrot: 4.5 - 6+
+  * LMDE
+  * Mint
+  * MX Linux
+  * Nitrux
+  * Parrot
   * Pop!_OS
-  * PureOS: 9 Amber - 10 Byzantium
+  * PureOS
   * Ubuntu
   * UOS: apricot - eagle
   * Zorin

--- a/README.md
+++ b/README.md
@@ -39,21 +39,22 @@ Before submitting a bug report in the [issue tracker](https://github.com/AdnanHo
 
 ## Supported platforms are:
 
+* BunsenLabs: Helium - Boron
   * Debian: Jessie 8.0/Stretch 9.0/Buster 10/Bullseye 11/Bookworm 12/Trixie(testing)/Sid (unstable)
-  * Ubuntu: 14.04 Trusty - 24.04 Noble
-  * elementary OS: 0.3 Freya- 7.0 Horus
-  * Mint: 15 Olivia - 21.3 Virginia
-  * LMDE: 2 Betsy - 6 Faye
-  * Kali: kali-rolling/2016.2 - 2023.1
   * Deepin: stable - unstable
-  * UOS: apricot - eagle
-  * MX Linux: 17.1/18
-  * BunsenLabs: Helium - Boron
-  * Parrot: 4.5 - 6+
   * Devuan: ASCII - Chimaera
-  * Pop!_OS: 20.04 Focal - 22.04 Jammy
-  * PureOS: 9 Amber - 10 Byzantium
+  * elementary OS: 0.3 Freya- 7.0 Horus
+  * Kali: kali-rolling/2016.2 - 2023.1
+  * KDE neon
+  * LMDE: 2 Betsy - 6 Faye
+  * Mint: 15 Olivia - 21.3 Virginia
+  * MX Linux: 17.1/18
   * Nitrux: nitrux
+  * Parrot: 4.5 - 6+
+  * Pop!_OS
+  * PureOS: 9 Amber - 10 Byzantium
+  * Ubuntu
+  * UOS: apricot - eagle
   * Zorin
 
   Regardless of which Linux kernel version (>4.15) you're using.

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -166,115 +166,47 @@ then
 # elementary OS
 elif [ "$lsb" == "elementary OS" ] || echo $lsb | grep -qi "elementary";
 then
-	if [ $codename == "freya" ] || [ $codename == "loki" ] || [ $codename == "juno" ] || [ $codename == "hera" ] || [ $codename == "odin" ] || [ $codename == "jolnir" ] || [ $codename == "horus" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # Debian
 elif [ "$lsb" == "Debian" ];
 then
-	if [ $codename == "jessie" ] || [ $codename == "stretch" ] || [ $codename == "buster" ] || [ $codename == "bullseye" ] || [ $codename == "bookworm" ] || [ $codename == "trixie" ] || [ $codename == "sid" ] || [ $codename == "n/a" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # Devuan
 elif [ "$lsb" == "Devuan" ]
 then
-    if [ "$codename" == "ascii" ] || [ "$codename" == "beowulf" ] || [ "$codename" == "chimaera" ];
-    then
-        echo -e "\nPlatform requirements satisfied, proceeding ..."
-    else
-        message
-        exit 1
-    fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # Mint
-# Issue 464	
 elif echo $lsb | grep -qi "Linuxmint" ;
 then
-	if [ $codename == "sarah" ] || [ $codename == "rosa" ] || [ $codename == "petra" ] || [ $codename == "olivia" ] || [ $codename == "serena" ] || [ $codename == "sonya" ] || [ $codename == "sylvia" ] || [ $codename == "tara" ] || [ $codename == "tessa" ] || [ $codename == "betsy" ] || [ $codename == "cindy" ] || [ $codename == "tina" ] || [ $codename == "tricia" ] || [ $codename == "debbie" ] || [ $codename == "ulyana" ] || [ $codename == "ulyssa" ] || [ $codename == "uma" ] || [ $codename == "una" ] || [ $codename == "elsie" ] || [ $codename == "vanessa" ] || [ $codename == "vera" ] || [ $codename == "victoria" ] || [ $codename == "faye" ] || [ $codename == "virginia" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # Kali
 elif [ "$lsb" == "Kali" ];
 then
-	# issue: 204
-	if [ $codename == "kali-rolling" ] || [ $codename == "2016.2" ] || [ $codename == "2017.3" ] || [ $codename == "2018.3" ] || [ $codename == "2018.4" ] || [ $codename == "2022.1" ] || [ $codename == "n/a" ] || [ $codename == "2022.2" ] || [ $codename == "2022.3" ] || [ $codename == "2022.4" ] || [ $codename == "2023.1" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # Deepin
 elif [ "$lsb" == "Deepin" ] || [ "$lsb" == "Uos" ] ;
 then
-	if [ $codename == "unstable" ] || [ $codename == "stable" ] || [ $codename == "eagle" ] || [ $codename == "apricot" ] || [ $codename == "n/a" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # MX Linux
 elif [ "$lsb" == "MX" ];
 then
-	if [ $codename == "Horizon" ] || [ $codename == "Continuum" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # BunsenLabs
 elif [ "$lsb" == "BunsenLabs" ] || [ "$lsb" == "Bunsenlabs" ];
 then
-	if [ $codename == "helium" ] || [ $codename == "lithium" ] || [ $codename == "beryllium" ] || [ $codename == "boron" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # Parrot
 elif [ "$lsb" == "Parrot" ];
 then
-	if [ $codename == "n/a" ] || [ $codename == "lts" ] || [ $codename == "ara" ] || [ $codename == "lory" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # PureOS
 elif [ "$lsb" == "PureOS" ];
 then
-	if [ $codename == "amber" ] || [ $codename == "byzantium" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # Nitrux
 elif [ "$lsb" == "Nitrux" ];
 then
-	if [ $codename == "nitrux" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi	
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # Zorin
 elif [ "$lsb" == "Zorin" ];
 then

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -162,13 +162,7 @@ echo -e "\n---------------------------------------------------------------\n"
 # Ubuntu, Neon, PopOS
 if [ "$lsb" == "Ubuntu" ] || [ "$lsb" == "Neon" ] || [ "$lsb" == "Pop" ];
 then
-	if [ $codename == "trusty" ] || [ $codename == "vivid" ] || [ $codename == "wily" ] || [ $codename == "xenial" ] || [ $codename == "yakkety" ] || [ $codename == "zesty" ] || [ $codename == "artful" ] || [ $codename == "bionic" ] || [ $codename == "cosmic" ] || [ $codename == "disco" ] || [ $codename == "eoan" ] || [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ] || [ $codename == "impish" ] || [ $codename == "jammy" ] || [ $codename == "kinetic" ] || [ $codename == "lunar" ] || [ $codename == "mantic" ] || [ $codename == "noble" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
+	echo -e "\nPlatform requirements satisfied, proceeding ..."
 # elementary OS
 elif [ "$lsb" == "elementary OS" ] || echo $lsb | grep -qi "elementary";
 then

--- a/displaylink-debian.sh
+++ b/displaylink-debian.sh
@@ -159,8 +159,8 @@ echo -e "GitHub repo: https://github.com/AdnanHodzic/displaylink-debian/"
 echo -e "\n---------------------------------------------------------------\n"
 }
 
-# Ubuntu
-if [ "$lsb" == "Ubuntu" ] || [ "$lsb" == "Neon" ];
+# Ubuntu, Neon, PopOS
+if [ "$lsb" == "Ubuntu" ] || [ "$lsb" == "Neon" ] || [ "$lsb" == "Pop" ];
 then
 	if [ $codename == "trusty" ] || [ $codename == "vivid" ] || [ $codename == "wily" ] || [ $codename == "xenial" ] || [ $codename == "yakkety" ] || [ $codename == "zesty" ] || [ $codename == "artful" ] || [ $codename == "bionic" ] || [ $codename == "cosmic" ] || [ $codename == "disco" ] || [ $codename == "eoan" ] || [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ] || [ $codename == "impish" ] || [ $codename == "jammy" ] || [ $codename == "kinetic" ] || [ $codename == "lunar" ] || [ $codename == "mantic" ] || [ $codename == "noble" ];
 	then
@@ -255,16 +255,6 @@ then
 elif [ "$lsb" == "Parrot" ];
 then
 	if [ $codename == "n/a" ] || [ $codename == "lts" ] || [ $codename == "ara" ] || [ $codename == "lory" ];
-	then
-		echo -e "\nPlatform requirements satisfied, proceeding ..."
-	else
-		message
-		exit 1
-	fi
-# PopOS
-elif [ "$lsb" == "Pop" ];
-then
-	if [ $codename == "focal" ] || [ $codename == "groovy" ] || [ $codename == "hirsute" ] || [ $codename == "impish" ] || [ $codename == "jammy" ] || [ $codename == "n/a" ];
 	then
 		echo -e "\nPlatform requirements satisfied, proceeding ..."
 	else


### PR DESCRIPTION
This PR removes the guards where we check for known distro releases. This should prevent breaking installs when a new distro release is installed.